### PR TITLE
fix #6: console errors when viewing old posts

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,13 +72,13 @@ function doWork() {
 
   const articleViewDateSections = document.querySelectorAll(globalSelectors.articleDate);
 
-  if(articleViewDateSections.length) {
+  if (articleViewDateSections.length) {
     // the rootDateViewsSection will always be the parent->parent->parent of the last element of the articleDate querySelectorAll result
     let rootDateViewsSection = articleViewDateSections[articleViewDateSections.length - 1].parentElement.parentElement.parentElement;
 
     // if there is one child, that means it's an old tweet with no viewcount
     // if there are more than 4, we already added the paycheck value
-    if(rootDateViewsSection?.children?.length !== 1 && rootDateViewsSection?.children.length < 4) {
+    if (rootDateViewsSection?.children?.length !== 1 && rootDateViewsSection?.children.length < 4) {
       // clone 2nd and 3rd child of rootDateViewsSection
       const clonedDateViewSeparator =
         rootDateViewsSection?.children[1].cloneNode(true);

--- a/main.js
+++ b/main.js
@@ -70,24 +70,15 @@ function doWork() {
     document.querySelectorAll(globalSelectors.viewCount)
   );
 
-  const articleViewDateSection = document.querySelector(
-    globalSelectors.articleDate
-  );
+  const articleViewDateSections = document.querySelectorAll(globalSelectors.articleDate);
 
-  if (articleViewDateSection) {
-    let rootDateViewsSection =
-      articleViewDateSection.parentElement.parentElement.parentElement;
+  if(articleViewDateSections.length) {
+    // the rootDateViewsSection will always be the parent->parent->parent of the last element of the articleDate querySelectorAll result
+    let rootDateViewsSection = articleViewDateSections[articleViewDateSections.length - 1].parentElement.parentElement.parentElement;
 
-    if (rootDateViewsSection?.children.length === 1) {
-      // we're dealing with the <time> element on a quote retweet
-      // do globalSelector query again but with 2nd result
-      rootDateViewsSection = document.querySelectorAll(
-        globalSelectors.articleDate
-      )[1].parentElement.parentElement.parentElement;
-    }
-
+    // if there is one child, that means it's an old tweet with no viewcount
     // if there are more than 4, we already added the paycheck value
-    if (rootDateViewsSection?.children.length < 4) {
+    if(rootDateViewsSection?.children?.length !== 1 && rootDateViewsSection?.children.length < 4) {
       // clone 2nd and 3rd child of rootDateViewsSection
       const clonedDateViewSeparator =
         rootDateViewsSection?.children[1].cloneNode(true);


### PR DESCRIPTION
I've fixed the errors while viewing old posts and quotes. Along with that, I've tried to keep the $ design and behavior same (empty) as the view count for older posts. Below are some screenshots of older and newer posts:

![old quote](https://github.com/t3dotgg/paycheck-extension/assets/55179845/49f5d1c0-096b-4b00-8f3d-98af6286f672)
![old comments](https://github.com/t3dotgg/paycheck-extension/assets/55179845/4d41d16c-fa91-4f7a-b3e2-851ab3830eae)
![new quote](https://github.com/t3dotgg/paycheck-extension/assets/55179845/a00ed326-eb1b-4a43-ba02-255824f396a4)
