### PR TITLE
Display paycheck on tweetdeck

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,12 @@
   "content_scripts": [
     {
       "run_at": "document_end",
-      "matches": ["https://twitter.com/*", "https://mobile.twitter.com/*", "https://x.com/*"],
+      "matches": [
+        "https://twitter.com/*",
+        "https://mobile.twitter.com/*",
+        "https://tweetdeck.twitter.com/*",
+        "https://x.com/*"
+      ],
       "js": ["main.js"]
     }
   ]


### PR DESCRIPTION
before, it's not on there
after:
![image](https://github.com/t3dotgg/paycheck-extension/assets/29130894/48a3bb83-b438-4cac-a4f9-58d62db41e5e)
![image](https://github.com/t3dotgg/paycheck-extension/assets/29130894/377d1d99-2cfe-480c-b155-27c02c4c8b37)

eventually tweetdeck will become "XPro" but we don't know the subdomain on x.com for that (pro.x.com and xpro.x.com redirect to pro.twitter.com and xpro.twitter.com, which don't do anything).