### PR TITLE
Feat/color

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ innerSelectors.viewSVG = "div div:first-child svg";
 innerSelectors.viewAmount = "div div:last-child span span span";
 innerSelectors.articleViewAmount = "span div:first-child span span span";
 
+const colorPaycheck = "255, 122, 0";
+
 function doWork() {
   const viewCounts = Array.from(
     document.querySelectorAll(globalSelectors.viewCount)
@@ -85,27 +87,30 @@ function doWork() {
       // insert dollarBox after view count
       parent.parentElement.insertBefore(dollarBox, parent.nextSibling);
 
-      // remove view count icon
       const oldIcon = dollarBox.querySelector(innerSelectors.viewSVG);
-      oldIcon?.remove();
-
-      // swap the svg for a dollar sign
-      const dollarSpot = dollarBox.querySelector(innerSelectors.dollarSpot)?.firstChild?.firstChild;
-      dollarSpot.textContent = "$";
-
-      dollarSpot.style.transition = "color 0.2s, background-color 0.2s";
+      
+      oldIcon.style.transition = "color 0.2s";
 
       // magic alignment value
-      dollarSpot.style.marginTop = "-0.6rem";
+      oldIcon.style.marginBottom = "-0.25rem";
+      // replace svg content with dollar sign
+      oldIcon.innerHTML = `<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="1.5rem">$</text>`
+      
+      // swap the svg for a dollar sign
+      const dollarSpot = dollarBox.querySelector(innerSelectors.dollarSpot)?.firstChild?.firstChild;
+      dollarSpot.style.transition = "color 0.2s, background-color 0.2s";
+
       // mimick the platform hover colors transition
       dollarBox.onmouseover = () => {
-        dollarSpot.style.color = "rgb(255, 230, 50)";
+        oldIcon.style.color = `rgb(${colorPaycheck})`;
+        dollarSpot.style.backgroundColor = `rgb(${colorPaycheck}, 0.1)`;
         
-        dollarAmountArea.style.color = "rgb(255, 230, 50)";
+        dollarAmountArea.style.color = `rgb(${colorPaycheck})`;
       }
 
       dollarBox.onmouseout = () => {
-        dollarSpot.style.color = "";
+        oldIcon.style.color = "";
+        dollarSpot.style.backgroundColor = "";
         
         dollarAmountArea.style.color = "";
       }
@@ -118,7 +123,7 @@ function doWork() {
     const dollarAmountArea = dollarBox.querySelector(innerSelectors.viewAmount);
     dollarAmountArea.textContent = convertToDollars(viewCount);
 
-    dollarAmountArea.style.transition = "color 0.2s ease";
+    dollarAmountArea.style.transition = "color 0.2s ease, background-color 0.2s ease";
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -93,8 +93,22 @@ function doWork() {
       const dollarSpot = dollarBox.querySelector(innerSelectors.dollarSpot)?.firstChild?.firstChild;
       dollarSpot.textContent = "$";
 
+      dollarSpot.style.transition = "color 0.2s, background-color 0.2s";
+
       // magic alignment value
       dollarSpot.style.marginTop = "-0.6rem";
+      // mimick the platform hover colors transition
+      dollarBox.onmouseover = () => {
+        dollarSpot.style.color = "rgb(255, 230, 50)";
+        
+        dollarAmountArea.style.color = "rgb(255, 230, 50)";
+      }
+
+      dollarBox.onmouseout = () => {
+        dollarSpot.style.color = "";
+        
+        dollarAmountArea.style.color = "";
+      }
     }
 
     // get the number of views and calculate & set the dollar amount
@@ -103,6 +117,8 @@ function doWork() {
     if (viewCount == undefined) continue;
     const dollarAmountArea = dollarBox.querySelector(innerSelectors.viewAmount);
     dollarAmountArea.textContent = convertToDollars(viewCount);
+
+    dollarAmountArea.style.transition = "color 0.2s ease";
   }
 }
 
@@ -133,7 +149,7 @@ const observe = () => {
     if (!mutationsList.length) return;
 
     const runDocumentMutations = throttle(async () => {
-      doWork();
+      requestAnimationFrame(doWork);
     }, 1000);
 
     runDocumentMutations();


### PR DESCRIPTION
# Description

## Changed

- Dollar sign text added to the `svg` element as `<text>` for style constancy

## Added

- Paycheck action icon background and color hover effect with a transition
- Paycheck action text color hover effect with a transition

## Color explanation

The paycheck action color was taken from the platform's display accent options - orange `rgb(255, 122, 0)`. The initial idea was to utilize an rgb variant of the yellow (gold-like) color similar to all the other action colors on the platform, but it introduced a color contrast issue when browsing in the "light" mode.

![payx-hover-demo-yellow](https://github.com/t3dotgg/paycheck-extension/assets/16290753/f1d81f02-f281-494f-88b3-f97ff6933742)

Here're the examples of how the selected color looks like in all themes:

![payx-hover-demo-lightsout](https://github.com/t3dotgg/paycheck-extension/assets/16290753/1e798ce7-a11c-418f-b733-2402846b4965)

![payx-hover-demo-dim](https://github.com/t3dotgg/paycheck-extension/assets/16290753/fe812311-ea2e-4297-b689-12bc07714d94)

![payx-hover-demo-default](https://github.com/t3dotgg/paycheck-extension/assets/16290753/fdc16c60-519b-47ce-b208-446320d76579)

Closes: #19